### PR TITLE
Patch the Mongo Instrumentation library

### DIFF
--- a/lib/rpm_contrib/instrumentation/mongo.rb
+++ b/lib/rpm_contrib/instrumentation/mongo.rb
@@ -22,7 +22,7 @@ DependencyDetection.defer do
           name, collection = f if f
         end
 
-        trace_execution_scoped("Database/#{collection}/#{name}") do
+        self.class.trace_execution_scoped("Database/#{collection}/#{name}") do
           t0 = Time.now
           res = instrument_without_newrelic_trace(name, payload, &blk)
           NewRelic::Agent.instance.transaction_sampler.notice_sql(payload.inspect, nil, (Time.now - t0).to_f)


### PR DESCRIPTION
the `Mongo::CollectionCommandWriter` class in the mongo ruby driver v1.12.5 requires the #trace_execution_scoped to be a class method